### PR TITLE
Teams, Roles and more

### DIFF
--- a/cmd/backupget.go
+++ b/cmd/backupget.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// backupgetCmd represents the alerts command
+// backupgetCmd represents the backups get command
 var backupgetCmd = &cobra.Command{
 	Use:   "get [deployment id] [backup id]",
 	Short: "Show Backup details for deployment",

--- a/cmd/backuplist.go
+++ b/cmd/backuplist.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// backuplistCmd represents the alerts command
+// backuplistCmd represents the backups list command
 var backuplistCmd = &cobra.Command{
 	Use:   "list [deployment id]",
 	Short: "Show Backups for deployment",

--- a/cmd/backuprestore.go
+++ b/cmd/backuprestore.go
@@ -25,8 +25,8 @@ var restoreclusterid string
 var restoredatacenterid string
 var restoressl bool
 
-// restoreCmd represents the deployment command
-var restoreCmd = &cobra.Command{
+// backuprestoreCmd represents the backups restore command
+var backuprestoreCmd = &cobra.Command{
 	Use:   "restore [deployment id] [backup id] [new deployment name]",
 	Short: "Restore a deployment",
 	Long:  `Restores a deployment. Requires deployment id, backup id, and new deployment name.`,
@@ -74,8 +74,8 @@ var restoreCmd = &cobra.Command{
 }
 
 func init() {
-	backupsCmd.AddCommand(restoreCmd)
-	restoreCmd.Flags().StringVar(&restoreclusterid, "cluster", "", "Cluster Id")
-	restoreCmd.Flags().StringVar(&restoredatacenterid, "datacenter", "", "Datacenter region")
-	restoreCmd.Flags().BoolVar(&ssl, "ssl", false, "SSL required (where supported)")
+	backupsCmd.AddCommand(backuprestoreCmd)
+	backuprestoreCmd.Flags().StringVar(&restoreclusterid, "cluster", "", "Cluster Id")
+	backuprestoreCmd.Flags().StringVar(&restoredatacenterid, "datacenter", "", "Datacenter region")
+	backuprestoreCmd.Flags().BoolVar(&ssl, "ssl", false, "SSL required (where supported)")
 }

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RootCmd represents the base command when called without any subcommands
+// RootCmd represents the backups subcommand
 var backupsCmd = &cobra.Command{
 	Use:   "backups",
 	Short: "Commands for backups",

--- a/cmd/backupstart.go
+++ b/cmd/backupstart.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// backupstartCmd represents the alerts command
+// backupstartCmd represents the backups start command
 var backupstartCmd = &cobra.Command{
 	Use:   "start [deployment id]",
 	Short: "Start backups for a deployment",

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,7 +27,7 @@ var version string
 var ssl bool
 var wiredtiger bool
 
-// createCmd represents the deployment command
+// createCmd represents the create-deployment command
 var createCmd = &cobra.Command{
 	Use:   "create [deployment name] [database type]",
 	Short: "Create a deployment",

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -26,7 +26,7 @@ var dbtype string
 var longoutput bool
 var filter string
 
-// deploymentsCmd represents the deployments command
+// deploymentsCmd represents the list deployments command
 var deploymentsCmd = &cobra.Command{
 	Use:   "deployments",
 	Short: "Show deployments attached to account",

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -23,6 +23,10 @@ import (
 	composeAPI "github.com/compose/gocomposeapi"
 )
 
+//
+// A selection of helper utilities to print common structs
+//
+
 func printRecipe(recipe composeAPI.Recipe) {
 	fmt.Printf("%15s: %s\n", "ID", recipe.ID)
 	fmt.Printf("%15s: %s\n", "Template", recipe.Template)

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setCmd represents the set command
+// setCmd represents the scale set command
 var setCmd = &cobra.Command{
 	Use:   "set [deployment id] [scale in integer units]",
 	Short: "Set scale for a deployment",

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RootCmd represents the base command when called without any subcommands
+// teamsCmd represents the teams subcommand
 var teamsCmd = &cobra.Command{
 	Use:   "teams",
 	Short: "Commands for teams",

--- a/cmd/teamscreate.go
+++ b/cmd/teamscreate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// teamsCreateCmd represents the alerts command
+// teamsCreateCmd represents the teams create command
 var teamsCreateCmd = &cobra.Command{
 	Use:   "create [team name]",
 	Short: "Create named team",

--- a/cmd/teamsget.go
+++ b/cmd/teamsget.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// teamslistCmd represents the alerts command
+// teamslistCmd represents the teams get command
 var teamsgetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "get team details",

--- a/cmd/teamslist.go
+++ b/cmd/teamslist.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// teamslistCmd represents the alerts command
+// teamslistCmd represents the teams list command
 var teamslistCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Show teams",

--- a/cmd/teamsusers.go
+++ b/cmd/teamsusers.go
@@ -97,7 +97,14 @@ var teamsremCmd = &cobra.Command{
 	},
 }
 
+var teamsUserCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Commands for team users",
+	Long:  `A selection of subcommands are available for listing, modifying and deleting team users`,
+}
+
 func init() {
-	teamsCmd.AddCommand(teamsaddCmd)
-	teamsCmd.AddCommand(teamsremCmd)
+	teamsCmd.AddCommand(teamsUserCmd)
+	teamsUserCmd.AddCommand(teamsaddCmd)
+	teamsUserCmd.AddCommand(teamsremCmd)
 }

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -38,7 +38,6 @@ var usersCmd = &cobra.Command{
 				for _, user := range users {
 					fmt.Printf("%15s: %s\n", "ID", user.ID)
 					fmt.Printf("%15s: %s\n", "Name", user.Name)
-
 					fmt.Println()
 				}
 			} else {
@@ -50,5 +49,4 @@ var usersCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(usersCmd)
-
 }


### PR DESCRIPTION
A lot of tidy up

The new teams commands - 

Usage:
  bach teams [command]

Available Commands:
  create      Create named team
  get         get team details
  list        Show teams
  user        Commands for team users

Usage:
  bach roles [command]

Available Commands:
  add         add a team to a deployment with a role
  del         removes a team from a role on a deployment
  get         get teams and roles

