### PR TITLE
Name support

### DIFF
--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -23,20 +23,24 @@ import (
 
 // alertsCmd represents the alerts command
 var alertsCmd = &cobra.Command{
-	Use:   "alerts [deployment id]",
+	Use:   "alerts [deployment id/name]",
 	Short: "Show Alerts for deployment",
 	Long:  `Show the alerts for a deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := getComposeAPI()
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
+		}
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
 		}
 		if outputRaw {
-			text, errs := c.GetAlertsForDeploymentJSON(args[0])
+			text, errs := c.GetAlertsForDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			alerts, errs := c.GetAlertsForDeployment(args[0])
+			alerts, errs := c.GetAlertsForDeployment(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/backupget.go
+++ b/cmd/backupget.go
@@ -23,20 +23,25 @@ import (
 
 // backupgetCmd represents the backups get command
 var backupgetCmd = &cobra.Command{
-	Use:   "get [deployment id] [backup id]",
+	Use:   "get [deployment id] [backup id/name]",
 	Short: "Show Backup details for deployment",
 	Long:  `Show the backup details for a deployment's backup`,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := getComposeAPI()
 		if len(args) != 2 {
-			log.Fatal("Need a deployment id and a backup id")
+			log.Fatal("Need a deployment id/name and a backup id")
 		}
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		backupid := args[1]
 		if outputRaw {
-			text, errs := c.GetBackupDetailsForDeploymentJSON(args[0], args[1])
+			text, errs := c.GetBackupDetailsForDeploymentJSON(depid, backupid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			backup, errs := c.GetBackupDetailsForDeployment(args[0], args[1])
+			backup, errs := c.GetBackupDetailsForDeployment(depid, backupid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/backuplist.go
+++ b/cmd/backuplist.go
@@ -23,20 +23,24 @@ import (
 
 // backuplistCmd represents the backups list command
 var backuplistCmd = &cobra.Command{
-	Use:   "list [deployment id]",
+	Use:   "list [deployment id/name]",
 	Short: "Show Backups for deployment",
 	Long:  `Show the backups for a deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := getComposeAPI()
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
+		}
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
 		}
 		if outputRaw {
-			text, errs := c.GetBackupsForDeploymentJSON(args[0])
+			text, errs := c.GetBackupsForDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			backups, errs := c.GetBackupsForDeployment(args[0])
+			backups, errs := c.GetBackupsForDeployment(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/backuprestore.go
+++ b/cmd/backuprestore.go
@@ -27,9 +27,9 @@ var restoressl bool
 
 // backuprestoreCmd represents the backups restore command
 var backuprestoreCmd = &cobra.Command{
-	Use:   "restore [deployment id] [backup id] [new deployment name]",
+	Use:   "restore [deployment id/name] [backup id] [new deployment name]",
 	Short: "Restore a deployment",
-	Long:  `Restores a deployment. Requires deployment id, backup id, and new deployment name.`,
+	Long:  `Restores a deployment. Requires deployment id/name, backup id, and new deployment name.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := getComposeAPI()
 		if outputRaw {
@@ -37,14 +37,17 @@ var backuprestoreCmd = &cobra.Command{
 		}
 
 		if len(args) != 3 {
-			log.Fatal("Need deployment id, backup id and new deployment name")
+			log.Fatal("Need deployment id/name, backup id and new deployment name")
 		}
 
 		if restoredatacenterid == "" && restoreclusterid == "" {
 			log.Fatal("Must supply either a --cluster id or --datacenter region")
 		}
 
-		deploymentid := args[0]
+		deploymentid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		backupid := args[1]
 		deploymentname := args[2]
 

--- a/cmd/backupstart.go
+++ b/cmd/backupstart.go
@@ -23,20 +23,24 @@ import (
 
 // backupstartCmd represents the backups start command
 var backupstartCmd = &cobra.Command{
-	Use:   "start [deployment id]",
+	Use:   "start [deployment id/name]",
 	Short: "Start backups for a deployment",
 	Long:  `Start an on-demand backups for a deployment. Will return the recipe performing the backup.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := getComposeAPI()
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
+		}
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
 		}
 		if outputRaw {
-			text, errs := c.StartBackupForDeploymentJSON(args[0])
+			text, errs := c.StartBackupForDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			recipe, errs := c.StartBackupForDeployment(args[0])
+			recipe, errs := c.StartBackupForDeployment(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/cacert.go
+++ b/cmd/cacert.go
@@ -24,15 +24,19 @@ import (
 
 // cacertCmd represents the cacert command
 var cacertCmd = &cobra.Command{
-	Use:   "cacert [deployment id]",
+	Use:   "cacert [deployment id/name]",
 	Short: "Returns the self-signed cert for the deployment",
 	Long:  `Returns the self-signed cert for the deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
 		}
 		c := getComposeAPI()
-		deployment, errs := c.GetDeployment(args[0])
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		deployment, errs := c.GetDeployment(depid)
 		bailOnErrs(errs)
 		decoded, err := base64.StdEncoding.DecodeString(deployment.CACertificateBase64)
 		if err != nil {

--- a/cmd/deprovision.go
+++ b/cmd/deprovision.go
@@ -23,20 +23,24 @@ import (
 
 // deprovisionCmd represents the deprovision command
 var deprovisionCmd = &cobra.Command{
-	Use:   "deprovision [deployment id]",
+	Use:   "deprovision [deployment id/name]",
 	Short: "Deprovision a deployment",
 	Long:  `.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
 		}
 		c := getComposeAPI()
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		if outputRaw {
-			text, errs := c.DeprovisionDeploymentJSON(args[0])
+			text, errs := c.DeprovisionDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			recipe, errs := c.DeprovisionDeployment(args[0])
+			recipe, errs := c.DeprovisionDeployment(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/details.go
+++ b/cmd/details.go
@@ -23,20 +23,24 @@ import (
 
 // detailsCmd represents the details command
 var detailsCmd = &cobra.Command{
-	Use:   "details [deployment id]",
+	Use:   "details [deployment id/name]",
 	Short: "Show details for a deployment",
 	Long:  `Show the details for a deployment including connection strings and certificates`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id")
+			log.Fatal("Need a deployment id/name")
 		}
 		c := getComposeAPI()
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		if outputRaw {
-			text, errs := c.GetDeploymentJSON(args[0])
+			text, errs := c.GetDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			deployment, errs := c.GetDeployment(args[0])
+			deployment, errs := c.GetDeployment(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,69 @@
+// Copyright © 2017 Compose, an IBM Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var listdbtype string
+var listfilter string
+
+// listCmd represents the new list deployments command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List deployments attached to account",
+	Long:  `List the database deployments attached to an account.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		c := getComposeAPI()
+		if outputRaw {
+			text, errs := c.GetDeploymentsJSON()
+			bailOnErrs(errs)
+			fmt.Println(text)
+		} else {
+			deployments, errs := c.GetDeployments()
+			bailOnErrs(errs)
+
+			matcher, err := regexp.Compile(filter)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if !outputJSON {
+				fmt.Printf("%-24s %-14s %-40s\n", "ID", "Type", "Name")
+				fmt.Printf("%-24s %-14s %-40s\n", strings.Repeat("-", 24), strings.Repeat("-", 14), strings.Repeat("-", 40))
+
+				for _, v := range *deployments {
+					if (dbtype == "" || dbtype == v.Type) && matcher.MatchString(v.Name) {
+						fmt.Printf("%-24s %-14s %-40s\n", v.ID, v.Type, v.Name)
+					}
+				}
+			} else {
+				printAsJSON(deployments)
+			}
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(listCmd)
+	listCmd.Flags().StringVarP(&listdbtype, "type", "t", "", "Only this database type")
+	listCmd.Flags().StringVarP(&listfilter, "filter", "f", "", "Regular expression to filter names on")
+}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -23,20 +23,24 @@ import (
 
 // scaleCmd represents the scale command
 var scaleCmd = &cobra.Command{
-	Use:   "scale [deployment id]",
+	Use:   "scale [deployment id/name]",
 	Short: "Show scale information for a deployment",
 	Long:  `Show Scale information (including unit size) for a deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			log.Fatal("Need deployment id")
+			log.Fatal("Need deployment id/name")
 		}
 		c := getComposeAPI()
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		if outputRaw {
-			text, errs := c.GetScalingsJSON(args[0])
+			text, errs := c.GetScalingsJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			scalings, errs := c.GetScalings(args[0])
+			scalings, errs := c.GetScalings(depid)
 			bailOnErrs(errs)
 
 			if !outputJSON {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -25,18 +25,21 @@ import (
 
 // setCmd represents the scale set command
 var setCmd = &cobra.Command{
-	Use:   "set [deployment id] [scale in integer units]",
+	Use:   "set [deployment id/name] [scale in integer units]",
 	Short: "Set scale for a deployment",
 	Long:  `Sets the number of resource units (storage/memory) that should be available.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 2 {
-			log.Fatal("Need a deployment id and new units value")
+			log.Fatal("Need a deployment id/name and new units value")
 		}
 		c := getComposeAPI()
-
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		params := composeAPI.ScalingsParams{}
-		params.DeploymentID = args[0]
+		params.DeploymentID = depid
 		scaleval, err := strconv.Atoi(args[1])
 		if err != nil {
 			log.Fatal("Scale units must be integer")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -30,7 +30,7 @@ func getComposeAPI() (client *composeAPI.Client) {
 	if apiToken == "Your API Token" {
 		ostoken := os.Getenv("COMPOSEAPITOKEN")
 		if ostoken == "" {
-			log.Fatal("Token not set and COMPOSEAPITOKEN environment variable not set")
+			log.Fatal("Token not set and COMPOSEAPITOKEN environment variable not set - Get your token at https://app.compose.io/oauth/api_tokens")
 		}
 		apiToken = ostoken
 	}

--- a/cmd/versions.go
+++ b/cmd/versions.go
@@ -23,20 +23,24 @@ import (
 
 // versionsCmd represents the versions command
 var versionsCmd = &cobra.Command{
-	Use:   "versions [deployment id]",
+	Use:   "versions [deployment id/name]",
 	Short: "Show versions for deployment database",
 	Long:  `Shows all available upgrade versions for the database installed within a deployment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			log.Fatal("Need a deployment id to examine")
+			log.Fatal("Need a deployment id/name to examine")
 		}
 		c := getComposeAPI()
+		depid, err := resolveDepID(c, args[0])
+		if err != nil {
+			log.Fatal(err)
+		}
 		if outputRaw {
-			text, errs := c.GetVersionsForDeploymentJSON(args[0])
+			text, errs := c.GetVersionsForDeploymentJSON(depid)
 			bailOnErrs(errs)
 			fmt.Println(text)
 		} else {
-			versions, errs := c.GetVersionsForDeployment(args[0])
+			versions, errs := c.GetVersionsForDeployment(depid)
 			bailOnErrs(errs)
 			if !outputJSON {
 				for _, v := range *versions {


### PR DESCRIPTION
Added name support as alternative to deployment ids
Introduced new list command, more compact version of deployments command
Show where to find api tokens if COMPOSEAPITOKEN is not set.
